### PR TITLE
Remove 3.7 from CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This integration uses features that were added in Python 3.8 <https://www.python.org/dev/peps/pep-0572/>
No need to have 3.7 here anymore.

https://github.com/Cyr-ius/hass-livebox-component/blob/ae98dfd5629d6871c4e821e0cd2c8a1048c3e8e3/custom_components/livebox/__init__.py#L82