### PR TITLE
Add IPv6 prefix to WAN binary sensor state attributes

### DIFF
--- a/custom_components/livebox/binary_sensor.py
+++ b/custom_components/livebox/binary_sensor.py
@@ -57,6 +57,7 @@ class WanStatus(CoordinatorEntity[LiveboxDataUpdateCoordinator], BinarySensorEnt
             "last_connection_error": wstatus.get("LastConnectionError"),
             "wan_ipaddress": wstatus.get("IPAddress"),
             "wan_ipv6address": wstatus.get("IPv6Address"),
+            "wan_ipv6prefix": wstatus.get("IPv6DelegatedPrefix"),
             "uptime": uptime,
         }
         cwired = self.coordinator.data.get("count_wired_devices")


### PR DESCRIPTION
Add a new extra state attribute to get the IPv6 prefix.
Maybe a little bit technical but could be useful in some cases.
