### PR TITLE
Fix lints and Hassfest

### DIFF
--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -22,12 +22,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install flake8 pylint
+          python -m pip install flake8 pylint homeassistant
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
       - name: Lint with flake8
         run: |
-          pip install flake8
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
@@ -35,7 +34,6 @@ jobs:
 
       - name: Lint with pylint
         run: |
-          pip install pylint
           # stop the build if there are Pylint errors
           # there is a bug with E1136 (https://github.com/PyCQA/pylint/issues/1498)
           # so we temporarily disable it.

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   hacs:
     name: HACS Action
+    if: github.repository_owner == 'cyr-ius'
     runs-on: "ubuntu-latest"
     steps:
       - name: 📥 Checkout the repository

--- a/custom_components/livebox/device_tracker.py
+++ b/custom_components/livebox/device_tracker.py
@@ -46,6 +46,11 @@ class LiveboxDeviceScannerEntity(
 
         self._attr_name = self._device.get("Name")
         self._attr_unique_id = key
+        self._attr_device_info = {
+            "name": self.name,
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "via_device": (DOMAIN, self.box_id),
+        }
 
     @property
     def is_connected(self):
@@ -80,15 +85,6 @@ class LiveboxDeviceScannerEntity(
     def mac_address(self):
         """Return mac address."""
         return self.key
-
-    @property
-    def device_info(self):
-        """Return the device info."""
-        return {
-            "name": self.name,
-            "identifiers": {(DOMAIN, self.unique_id)},
-            "via_device": (DOMAIN, self.box_id),
-        }
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/livebox/services.yaml
+++ b/custom_components/livebox/services.yaml
@@ -1,11 +1,8 @@
 # Livebox service entries description.
 
-reboot:
-  # Description of the service
-  description: Restart the Livebox.
-
 remove_call_missed:
-  description: Remove call missed
+  name: Remove call missed
+  description: Remove a missed call or all if not any specified
   fields:
     callId:
       name: Call Id

--- a/custom_components/livebox/switch.py
+++ b/custom_components/livebox/switch.py
@@ -38,13 +38,13 @@ class WifiSwitch(CoordinatorEntity[LiveboxDataUpdateCoordinator], SwitchEntity):
         """Return true if device is on."""
         return self.coordinator.data.get("wifi")
 
-    async def async_turn_on(self):
+    async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
         parameters = {"Enable": "true", "Status": "true"}
         await self.hass.async_add_executor_job(self._api.wifi.set_wifi, parameters)
         await self.coordinator.async_request_refresh()
 
-    async def async_turn_off(self):
+    async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
         parameters = {"Enable": "false", "Status": "false"}
         await self.hass.async_add_executor_job(self._api.wifi.set_wifi, parameters)
@@ -70,7 +70,7 @@ class GuestWifiSwitch(CoordinatorEntity, SwitchEntity):
         """Return true if device is on."""
         return self.coordinator.data.get("guest_wifi")
 
-    async def async_turn_on(self):
+    async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
         parameters = {"Enable": "true", "Status": "true"}
         await self.hass.async_add_executor_job(
@@ -78,7 +78,7 @@ class GuestWifiSwitch(CoordinatorEntity, SwitchEntity):
         )
         await self.coordinator.async_request_refresh()
 
-    async def async_turn_off(self):
+    async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
         parameters = {"Enable": "false", "Status": "false"}
         await self.hass.async_add_executor_job(

--- a/custom_components/livebox/translations/en.json
+++ b/custom_components/livebox/translations/en.json
@@ -1,6 +1,5 @@
 {
     "config": {
-        "title": "Orange Livebox",
         "step": {
             "user": {
                 "title": "Check your livebox",

--- a/custom_components/livebox/translations/fr.json
+++ b/custom_components/livebox/translations/fr.json
@@ -1,6 +1,5 @@
 {
   "config": {
-    "title": "Orange Livebox",
     "step": {
       "user": {
         "title": "Vérification de votre livebox.",

--- a/custom_components/livebox/translations/nb.json
+++ b/custom_components/livebox/translations/nb.json
@@ -1,6 +1,5 @@
 {
     "config": {
-        "title": "Orange Livebox",
         "step": {
             "user": {
                 "title": "Sjekk liveboxen din",


### PR DESCRIPTION
* Install homeassistant to avoid the actual error and don't run install commands twice in GH actions
* Fix remaining lint warnings
* Don't run HACS actions on forks
* Remove `reboot` from services.yaml
* Fix hassfest errors and warning