### PR TITLE
Fix release publishing by using a maintained action and without re-creating the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,10 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          name: ${{ github.ref }}
           body: ${{ steps.changelog.outputs.changelog }}
           draft: false
           prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Actual release action fails because tag is already created.
Also, the used action is not published anymore as specified by documentation.
This PR replaces action by a maintained one and without re-creating the tag, which should allow no more failure when publishing a release.
