### PR TITLE
Fix building diagnostics data

### DIFF
--- a/custom_components/livebox/diagnostics.py
+++ b/custom_components/livebox/diagnostics.py
@@ -35,6 +35,7 @@ TO_REDACT = {
     "dateOfBirth",
     "nickname",
     "placeOfBirth",
+    "KeyPassPhrase",
 }
 
 _LOGGER = logging.getLogger(__name__)
@@ -58,7 +59,7 @@ async def async_get_config_entry_diagnostics(
         # api.connection.get_dsl0_DSLStats,  # Exception: [{'error': 196618, 'description': 'Object or parameter not found', 'info': 'NeMo.Intf.dsl0'}]
         # api.connection.get_dsl0_MIBS,  # Exception: [{'error': 196618, 'description': 'Object or parameter not found', 'info': 'NeMo.Intf.dsl0'}]
         api.connection.get_data_MIBS,
-        api.connection.get_lan_MIBS,
+        api.connection.get_lan_MIBS,  # return WLANs passkey as KeyPassPhrase
         api.system.get_nmc,
         api.wifi.get_wifi,
         api.guestwifi.get_guest_wifi,
@@ -162,5 +163,5 @@ async def async_get_config_entry_diagnostics(
             "options": async_redact_data(entry.options, TO_REDACT),
         },
         "data": async_redact_data(coordinator.data, TO_REDACT),
-        "api_raw": api_raw,
+        "api_raw": async_redact_data(api_raw, TO_REDACT),
     }

--- a/custom_components/livebox/diagnostics.py
+++ b/custom_components/livebox/diagnostics.py
@@ -151,7 +151,7 @@ async def async_get_config_entry_diagnostics(
                     else f"Can't dump {str(type(result))} data"
                 )
             )
-        except Exception as err:
+        except Exception as err:  # pylint: disable=broad-exception-caught
             api_raw[api_method.__qualname__] = f"Exception: {err}"
     _LOGGER.debug("Diagnostics data builded in %0.1fs", time() - start_time)
 


### PR DESCRIPTION
I see you publish this new feature and I tested it on my dev environment. Their was some mistakes about the name of API methods which I first corrected (`api.ddns.*` vs `api.dyndns.*`, `api.profile.*` vs `api.profiles.*`, ...), but their was also errors about async methods not await (and `api_raw` was empty), so I reworked on the method to build `api_raw`.

After, I was able to download a diagnostics JSON file, but it's taken around 30 seconds to build it and its size was approximately 50MB. I noticed that it was mostly due to 3 called methods, so I commented them. Now, the file is generated in 4 seconds and its size is approximately 1.3MB.

Furthermore, many methods always failed, so I firstly put the produced exception in the diagnostics file and I commented them (with exception). I think we could at least remove some of them that required arguments.

Please let me know what you think.