### PR TITLE
Fix buttons initialization

### DIFF
--- a/custom_components/livebox/button.py
+++ b/custom_components/livebox/button.py
@@ -29,7 +29,7 @@ class RestartButton(ButtonEntity):
 
     def __init__(self, coordinator: LiveboxDataUpdateCoordinator) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator)
+        super().__init__()
         self.coordinator = coordinator
         self._attr_unique_id = f"{coordinator.unique_id}_restart"
         self._attr_device_info = {"identifiers": {(DOMAIN, coordinator.unique_id)}}
@@ -48,7 +48,7 @@ class RingButton(ButtonEntity):
 
     def __init__(self, coordinator: LiveboxDataUpdateCoordinator) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator)
+        super().__init__()
         self.coordinator = coordinator
         self._attr_unique_id = f"{coordinator.unique_id}_ring"
         self._attr_device_info = {"identifiers": {(DOMAIN, coordinator.unique_id)}}


### PR DESCRIPTION
Après avoir installé la version 2.0.6, il restait un petit button sur l'initialisation des boutons (c'est pas des `CoordinatorEntity` comme les autres entités). Pour le reste, tout semble fonctionner correctement chez moi.