### PR TITLE
Support for reading ONT info from spanish Sagecom routers

### DIFF
--- a/custom_components/livebox/coordinator.py
+++ b/custom_components/livebox/coordinator.py
@@ -50,7 +50,6 @@ class LiveboxDataUpdateCoordinator(DataUpdateCoordinator):
         )
         self.unique_id: str | None = None
         self.model: int | None = None
-        self.is_sagecom: bool = False
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data."""
@@ -70,7 +69,7 @@ class LiveboxDataUpdateCoordinator(DataUpdateCoordinator):
                 case "Livebox 7":
                     self.model = 7
                 case "SMBSLBFIBRA":
-                    self.is_sagecom = True
+                    self.model = 5656  # Sagemcom f@st 5656
             # Optionals
             wifi_tracking = self.config_entry.options.get(
                 CONF_WIFI_TRACKING, DEFAULT_WIFI_TRACKING
@@ -171,7 +170,7 @@ class LiveboxDataUpdateCoordinator(DataUpdateCoordinator):
         """Get fiber status."""
         if self.model == 4 or self.model == 3:
             return {}
-        if self.is_sagecom:
+        if self.model == 5656:
             async def async_get_optical():
                 return await self.api._auth.post("SgcOmci.Optical", "get")
             optical = (await self._make_request(async_get_optical)).get('status', {})


### PR DESCRIPTION
I have a Spanish livebox router. While this HA integration works for some fields, it didn't work for the fiber-optic TX power and RX power entities.

Apparetly it's possible to fetch the ONT info via the `SgcOmci.Optical` sysbus endpoint. Since `AIOSysbus` doesn't implement an API for that endpoint, the code for making the request is a bit dirty, and the units are different (dBm vs milli-dBm, which requires normalization) - but works.

For reference, the output of running `sysbus DeviceInfo:get` is:

```json
{
    "status": {
        "Manufacturer": "SMBS",
        "ManufacturerOUI": "F08175",
        "ModelName": "SagemcomFast5656_OSP",
        "Description": "SagemcomFast5656_OSP SMBS sp",
        "ProductClass": "SMBSLBFIBRA",
        "SerialNumber": "SMBS01234567",          // (redacted)
        "HardwareVersion": "SMBSLBFIB1.0.1",
        "SoftwareVersion": "SG_LBFIBRA_sip-sp-03.02.17.009",
        "RescueVersion": "SG_LBFIBRA_sip_resc-sp-03.02.17.009",
        "ModemFirmwareVersion": "",
        "EnabledOptions": "",
        "AdditionalHardwareVersion": "",
        "AdditionalSoftwareVersion": "g5-f-sip-sp",
        "SpecVersion": "1.1",
        "ProvisioningCode": "CONN.1234.1234.FTTH.1234.1234.ABCD.1234.1234.ABCD.1234.1234",          // (redacted)
        "UpTime": 103498,
        "FirstUseDate": "0001-01-01T00:00:00Z",
        "DeviceLog": "",
        "VendorConfigFileNumberOfEntries": 1,
        "ManufacturerURL": "http://www.sagemcom.com/",
        "Country": "sp",
        "ExternalIPAddress": "12.34.56.78",         // (redacted)
        "DeviceStatus": "Up",
        "NumberOfReboots": 4,
        "UpgradeOccurred": false,
        "ResetOccurred": false,
        "RestoreOccurred": false
    }
}
```

And the output of `sysbus SgcOmci.Optical:get` is:

```json
{
    "status": {
        "PowerRx": "-26.02",
        "PowerTx": "0.89",
        "BiasCurrent": "12.74",
        "Temperature": "38.75",
        "Vcc": "3.29"
    }
}
```

(Note that all `SgcOmci.Optical` values are wrapped in strings)