### PR TITLE
Add unsupported routers to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Only the routers with Livebox OS are supported:
 - KPN Box 12 (Firmware: V12.C.23.04.36)
 - Sagemcom f@st 5656
 
+### Unsupported routers
+
+Despite being labelled "Livebox", the following router models **cannot** be supported:
+
+- Arcadyan PRV3399 ("Livebox Plus")
+
 ## Presence Detection
 
 This platform offers presence detection by keeping track of the


### PR DESCRIPTION
Based on information from https://github.com/cyr-ius/hass-livebox-component/issues/185 . This should prevent confusion from some users.