### PR TITLE
Tweaks for the sagecom 5656

### DIFF
--- a/custom_components/livebox/coordinator.py
+++ b/custom_components/livebox/coordinator.py
@@ -288,6 +288,8 @@ class LiveboxDataUpdateCoordinator(DataUpdateCoordinator):
             intf = "eth0"
         elif self.model == 3:
             intf = "bridge_vmulti"
+        elif self.model == 5656:
+            intf = "bridge"
         else:
             intf = "veip0"
         return (
@@ -372,6 +374,9 @@ class LiveboxDataUpdateCoordinator(DataUpdateCoordinator):
         self, domain: str = "default"
     ) -> list[dict[str, Any]]:
         """Get dhcp leases."""
+        if self.model == 5656:
+            return []
+
         data = (
             await self._make_request(self.api.dhcp.async_get_dhcp_leases, None, domain)
         ).get("status", {})


### PR DESCRIPTION
Two (small but important) tweaks for the sagecom 5656:

- The fiber interface is not `veip0`, but rather `bridge`. `veip0` seems to be the internal switch, since it seems to sum the traffic from all interfaces (wl0+eth0..3+fiber)
- The `sysbus` calls to get the DHCP leases only return errors (and clog the HASS logs), so they are skipped.