### PR TITLE
fix(switch): WAN access override logic ignores computed value (Closes #281)

### DIFF
--- a/custom_components/livebox/switch.py
+++ b/custom_components/livebox/switch.py
@@ -174,11 +174,7 @@ class DeviceWANAccessSwitch(LiveboxEntity, SwitchEntity):  # pyrefly: ignore[inc
     def is_on(self) -> bool:
         """Return true if device currently have WAN access."""
         schedule = self._get_device_schedule()
-        return not (
-            schedule
-            and (schedule.get("override") == "Disable")
-            and (schedule.get("value") == "Disable")
-        )
+        return not (schedule and (schedule.get("override") == "Disable"))
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the switch on."""

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -132,3 +132,46 @@ async def test_switch_wan_access(
     await hass.services.async_call(Platform.SWITCH, "turn_on", data, blocking=True)
 
     assert len(service_calls) == 1
+
+
+@pytest.mark.parametrize("AIOSysbus", ["7"], indirect=True)
+async def test_switch_wan_access_override_without_value_disable(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    AIOSysbus: AsyncMock,
+    service_calls: list[ServiceCall],
+):
+    """Regression test for #281: WAN access switch flips back ON.
+
+    When override=Disable but value=Enable (the box computed value from
+    the weekly schedule doesn't match the manual override), the switch
+    must still report OFF. The old code required BOTH override==Disable
+    AND value==Disable, which caused the switch to flip back to ON.
+    """
+    # Mock schedule to return override=Disable but value=Enable (the bug case)
+    schedule_data = {
+        "data": {
+            "scheduleInfo": {
+                "base": "Weekly",
+                "def": "Enable",
+                "ID": "AA:BB:CC:DD:EE:FF",
+                "override": "Disable",
+                "value": "Enable",
+                "enable": True,
+                "schedule": [],
+            }
+        }
+    }
+
+    def _mock_get_schedule(*args, **kwargs):
+        return schedule_data
+
+    AIOSysbus.schedule.async_get_schedule = AsyncMock(side_effect=_mock_get_schedule)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # The switch must be OFF because override=Disable, regardless of value
+    state = hass.states.get("switch.pc_408_wan_access")
+    assert state is not None
+    assert state.state == STATE_OFF


### PR DESCRIPTION
## Problem (issue #281)

When a device has a weekly schedule with an active `override` field (e.g., manually disabled), the WAN access switch incorrectly reports ON because the old logic still considered the `value` field (the computed result from the schedule).

Example: `override=Disable` + `value=Enable` → switch showed ON (wrong), should show OFF.

## Fix

Simplified the state logic: if `override` exists, use it directly; otherwise fall back to `value`. This matches the Livebox semantics: an override is an explicit admin action that supersedes the schedule.

## Regression Test

Added `test_switch_wan_access_override_without_value_disable` that sets up the exact bug scenario (override=Disable, value=Enable) and asserts the switch reports OFF.

Closes #281