### PR TITLE
fix: prefix WAN access switch unique_id with serial + migration (Closes #287)

### DIFF
--- a/custom_components/livebox/__init__.py
+++ b/custom_components/livebox/__init__.py
@@ -1,12 +1,14 @@
 """Orange Livebox."""
 
 import logging
+import re
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 
 from .const import CALLID, DOMAIN, PLATFORMS
 from .coordinator import LiveboxDataUpdateCoordinator
@@ -18,16 +20,71 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
 
+# Matches the legacy format: "{mac}_wan_access" where mac contains colons/hyphens.
+# e.g. "AA:BB:CC:DD:EE:FF_wan_access"
+_LEGACY_WAN_ACCESS_RE = re.compile(
+    r"^([0-9A-Fa-f]{2}[:\-]){5}[0-9A-Fa-f]{2}_wan_access$"
+)
+
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Livebox integration."""
     return True
 
 
+def _migrate_wan_access_unique_ids(
+    hass: HomeAssistant,
+    entry: LiveboxConfigEntry,
+    serial: str,
+) -> None:
+    """Migrate WAN access switch unique_ids from legacy {mac}_wan_access format.
+
+    Prior to this fix (item 2b / issue #287), DeviceWANAccessSwitch set
+    unique_id = description.key = "{mac}_wan_access" — without the serial-number
+    prefix used by every other entity. This caused collisions when two Livebox
+    boxes were configured.
+
+    Migration: rename to "{serial}_{mac}_wan_access" so existing entities are
+    not orphaned after the upgrade.
+    """
+    entity_registry = er.async_get(hass)
+    migrated = 0
+    for entity_entry in er.async_entries_for_config_entry(
+        entity_registry, entry.entry_id
+    ):
+        uid = entity_entry.unique_id
+        if uid and _LEGACY_WAN_ACCESS_RE.match(uid):
+            new_uid = f"{serial}_{uid}"
+            _LOGGER.info(
+                "Migrating WAN access switch unique_id: %s → %s (issue #287)",
+                uid,
+                new_uid,
+            )
+            entity_registry.async_update_entity(
+                entity_entry.entity_id, new_unique_id=new_uid
+            )
+            migrated += 1
+    if migrated:
+        _LOGGER.info(
+            "Migrated %d WAN access switch unique_id(s) for entry %s",
+            migrated,
+            entry.entry_id,
+        )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: LiveboxConfigEntry) -> bool:
     """Set up Livebox as config entry."""
     coordinator = LiveboxDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
+
+    # If unique_id was cleared (migration) or missing, set it from SerialNumber
+    if entry.unique_id is None and coordinator.unique_id:
+        hass.config_entries.async_update_entry(entry, unique_id=coordinator.unique_id)
+
+    # Migrate legacy WAN access switch unique_ids (issue #287)
+    if coordinator.unique_id:
+        _migrate_wan_access_unique_ids(hass, entry, coordinator.unique_id)
+
     entry.runtime_data = coordinator
 
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))

--- a/custom_components/livebox/coordinator.py
+++ b/custom_components/livebox/coordinator.py
@@ -314,9 +314,7 @@ class LiveboxDataUpdateCoordinator(DataUpdateCoordinator):
             try:
                 utc_dt = datetime.strptime(start_time, "%Y-%m-%dT%H:%M:%SZ")
             except (ValueError, TypeError):
-                _LOGGER.debug(
-                    "Skipping call with unparsable startTime: %s", start_time
-                )
+                _LOGGER.debug("Skipping call with unparsable startTime: %s", start_time)
                 continue
             local_dt = utc_dt.replace(tzinfo=UTC).astimezone(tz=DEFAULT_TIME_ZONE)
             caller = {

--- a/custom_components/livebox/switch.py
+++ b/custom_components/livebox/switch.py
@@ -156,7 +156,7 @@ class DeviceWANAccessSwitch(LiveboxEntity, SwitchEntity):  # pyrefly: ignore[inc
         super().__init__(coordinator, description)
         self._device_key = device.get("Key", self.name)
         self._device = device
-        self._attr_unique_id = description.key
+        self._attr_unique_id = f"{coordinator.unique_id or DOMAIN}_{description.key}"
         unique_id = coordinator.unique_id or DOMAIN
         self._attr_device_info = DeviceInfo(
             name=self._device.get("Name"),

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -5,6 +5,7 @@ import pytest
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import entity_registry as er
 from sqlalchemy import false
 
 
@@ -132,3 +133,89 @@ async def test_switch_wan_access(
     await hass.services.async_call(Platform.SWITCH, "turn_on", data, blocking=True)
 
     assert len(service_calls) == 1
+
+
+@pytest.mark.parametrize("AIOSysbus", ["7"], indirect=True)
+async def test_switch_wan_access_override_without_value_disable(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    AIOSysbus: AsyncMock,
+    service_calls: list[ServiceCall],
+):
+    """Regression test for #281: WAN access switch flips back ON.
+
+    When override=Disable but value=Enable (the box computed value from
+    the weekly schedule doesn't match the manual override), the switch
+    must still report OFF. The old code required BOTH override==Disable
+    AND value==Disable, which caused the switch to flip back to ON.
+    """
+    # Mock schedule to return override=Disable but value=Enable (the bug case)
+    schedule_data = {
+        "data": {
+            "scheduleInfo": {
+                "base": "Weekly",
+                "def": "Enable",
+                "ID": "AA:BB:CC:DD:EE:FF",
+                "override": "Disable",
+                "value": "Enable",
+                "enable": True,
+                "schedule": [],
+            }
+        }
+    }
+
+    def _mock_get_schedule(*args, **kwargs):
+        return schedule_data
+
+    AIOSysbus.schedule.async_get_schedule = AsyncMock(side_effect=_mock_get_schedule)
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # The switch must be OFF because override=Disable, regardless of value
+    state = hass.states.get("switch.pc_408_wan_access")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+@pytest.mark.parametrize("AIOSysbus", ["7"], indirect=True)
+async def test_wan_access_switch_unique_id_migration(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    AIOSysbus: AsyncMock,
+) -> None:
+    """Migration test for issue #287: legacy unique_id without serial prefix.
+
+    Prior to this fix, DeviceWANAccessSwitch stored unique_id = "{mac}_wan_access"
+    without the serial-number prefix. The migration in async_setup_entry must
+    rename existing entries to "{serial}_{mac}_wan_access" so they are not
+    orphaned after upgrade.
+    """
+    serial = config_entry.unique_id  # "012345678901234" from fixture
+    mac = "AA:BB:CC:DD:EE:FF"
+    legacy_uid = f"{mac}_wan_access"
+    expected_uid = f"{serial}_{legacy_uid}"
+
+    entity_registry = er.async_get(hass)
+
+    # Pre-register an entity with the legacy unique_id (simulates a pre-upgrade entry)
+    old_entry = entity_registry.async_get_or_create(
+        domain="switch",
+        platform="livebox",
+        unique_id=legacy_uid,
+        config_entry=config_entry,
+        suggested_object_id="test_device_wan_access",
+    )
+    assert old_entry.unique_id == legacy_uid
+
+    # Run integration setup — migration should happen inside async_setup_entry
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # The entity must now carry the new prefixed unique_id
+    migrated = entity_registry.async_get(old_entry.entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == expected_uid
+
+    # No duplicate entry should exist under the old unique_id
+    assert entity_registry.async_get_entity_id("switch", "livebox", legacy_uid) is None


### PR DESCRIPTION
## Problem (issue #287)

`DeviceWANAccessSwitch` used `unique_id = '{mac}_wan_access'` without the serial-number prefix used by all other entities. In multi-box setups (two Livebox configured), this caused:

```
Some entities failed to create due to already existing unique ID
```

Because both boxes share the same device MAC addresses in their schedules.

## Fix

1. **switch.py**: `DeviceWANAccessSwitch._attr_unique_id` now uses `'{serial}_{mac}_wan_access'` format (consistent with all other entities)

2. **__init__.py**: Added `_migrate_wan_access_unique_ids()` — at setup time, scans the entity registry for entries matching the legacy pattern and renames them to the new format. This prevents orphaned entities after upgrade.

3. Also ensures `coordinator.unique_id` is set from `SerialNumber` if missing (covers the case where `entry.unique_id` was a boolean — a legacy bug from early versions).

## Regression Test

`test_wan_access_switch_unique_id_migration`: pre-registers an entity with the legacy unique_id, runs setup, and asserts the migration renames it correctly.

Closes #287